### PR TITLE
Add dependency check for jq

### DIFF
--- a/CVE-2023-27163.sh
+++ b/CVE-2023-27163.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
 
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is not installed. Please install jq to continue."
+    exit 1
+fi
+
 echo -e "Proof-of-Concept of SSRF on Request-Baskets (CVE-2023-27163) || More info at https://github.com/entr0pie/CVE-2023-27163\n";
 
 if [ "$#" -lt 2 ] || [ "$1" = "-h" ] || [ "$1" = "--help" ]; then


### PR DESCRIPTION
Great PoC! Just added one small fix that might be useful. This PR checks if jq is installed on the host, and if not exits and prints a message it needs to be installed.